### PR TITLE
Recipe-delete

### DIFF
--- a/backend/src/controllers/recipeController.js
+++ b/backend/src/controllers/recipeController.js
@@ -68,6 +68,15 @@ const RecipeController = {
       res.status(500).json({ error: "Failed to update recipe" });
     }
   },
+
+  async deleteRecipe(req, res) {
+    try {
+      await recipeService.deleteRecipe(req.params.id);
+      res.status(200).json({ message: "Recipe deleted successfully" });
+    } catch (error) {
+      res.status(500).json({ error: "Failed to delete recipe" });
+    }
+  },
 };
 
 export default RecipeController;

--- a/backend/src/repositories/recipeRepository.js
+++ b/backend/src/repositories/recipeRepository.js
@@ -51,6 +51,13 @@ const recipeRepository = {
       throw new Error("Failed to search recipes");
     }
   },
+  async deleteRecipe(id) {
+    try {
+      return await Recipe.findByIdAndDelete(id);
+    } catch (error) {
+      throw new Error("Failed to delete recipe");
+    }
+  },
 };
 
 export default recipeRepository;

--- a/backend/src/routes/recipeRoutes.js
+++ b/backend/src/routes/recipeRoutes.js
@@ -7,4 +7,5 @@ router.get("/search", RecipeController.searchRecipes);
 router.get("/:id", RecipeController.getRecipeById);
 router.put("/:id", RecipeController.updateRecipe);
 router.get("/", RecipeController.getAllRecipes);
+router.delete("/:id", RecipeController.deleteRecipe);
 export default router;

--- a/backend/src/services/recipeService.js
+++ b/backend/src/services/recipeService.js
@@ -1,17 +1,7 @@
 import recipeRepository from "../repositories/recipeRepository.js";
 
 const recipeService = {
-  async deleteRecipe(id) {
-    try {
-      const recipe = await recipeRepository.deleteRecipe(id);
-      if (!recipe) {
-        throw new Error("Recipe not found");
-      }
-      return recipe;
-    } catch (error) {
-      throw new Error("Failed to delete recipe");
-    }
-  },
+
   async createRecipe(recipeData) {
     try {
       const recipe = await recipeRepository.createRecipe(recipeData);
@@ -51,7 +41,14 @@ const recipeService = {
     } catch (error) {
       throw new Error("Failed to update recipe");
     }
-  }
+  },
+  async deleteRecipe(id) {
+    try {
+      await recipeRepository.deleteRecipe(id);
+    } catch (error) {
+      throw new Error("Failed to delete recipe");
+    }
+  },
 };
 
 export default recipeService;

--- a/frontend/app/components/recipes/RecipeDetail.tsx
+++ b/frontend/app/components/recipes/RecipeDetail.tsx
@@ -13,7 +13,9 @@ import recipeService from "@/service/recipeService"
 import type { RecipeIngredient } from "@/model/ingredient"
 import { Crepe } from "@milkdown/crepe";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { useNavigate } from "react-router";
 function RecipeDetail() {
+    const navigate = useNavigate();
     const { id } = useParams();
     const [recipe, setRecipe] = useState<Recipe | null>(null);
     const [loading, setLoading] = useState(true);
@@ -72,6 +74,18 @@ function RecipeDetail() {
         return <p>Recipe not found.</p>;
     }
 
+    const handleDeleteRecipe = async () => {
+        try {
+            const confirmed = window.confirm("Are you sure you want to delete this recipe?");
+            if (confirmed) {
+                await recipeService.deleteRecipe(id as string);
+                navigate("/app/recipes");
+            }
+        } catch (error) {
+            console.error("Error deleting recipe:", error);
+        }
+    };
+
     return (
         <div className="flex h-full flex-col">
             <div className="flex items-center justify-between p-4 border-b">
@@ -104,7 +118,7 @@ function RecipeDetail() {
                             </div>
                         </DialogContent>
                     </Dialog>
-                    <Button variant="outline" size="icon" className="text-destructive">
+                    <Button variant="outline" size="icon" className="text-destructive" onClick={handleDeleteRecipe}>
                         <Trash2 className="h-4 w-4" />
                         <span className="sr-only">Delete recipe</span>
                     </Button>

--- a/frontend/app/service/recipeService.ts
+++ b/frontend/app/service/recipeService.ts
@@ -98,6 +98,9 @@ export const recipeService = {
                     "Content-Type": "application/json"
                 },
             });
+            if (!response.ok) {
+                throw new Error(`Failed to delete recipe: ${response.status} ${response.statusText}`);
+            }
             return response.json();
         } catch (error) {
             console.error("Error deleting recipe:", error);

--- a/frontend/app/service/recipeService.ts
+++ b/frontend/app/service/recipeService.ts
@@ -87,6 +87,22 @@ export const recipeService = {
             console.error("Error getting recipes:", error);
             throw error;
         }
+    },
+    deleteRecipe: async (id: string) => {
+        try {
+            const token = await authService.getJwtToken();
+            const response = await fetch(`/api/recipes/${id}`, {
+                method: "DELETE",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json"
+                },
+            });
+            return response.json();
+        } catch (error) {
+            console.error("Error deleting recipe:", error);
+            throw error;
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces functionality to delete recipes in both the backend and frontend, along with corresponding tests. The changes include implementing the delete recipe feature in the backend API, integrating it into the frontend UI, and adding unit tests to ensure proper behavior.

### Backend Changes

* **Added delete recipe functionality in the backend:**
  - Implemented the `deleteRecipe` method in `recipeRepository` to handle database deletion using `Recipe.findByIdAndDelete`.
  - Added the `deleteRecipe` method in `recipeService` to call the repository method and handle errors.
  - Introduced the `deleteRecipe` controller in `RecipeController` to respond to client requests and return appropriate HTTP status codes.
  - Updated the `recipeRoutes` file to include a new DELETE route (`router.delete("/:id")`) for recipe deletion.

### Frontend Changes

* **Integrated delete recipe functionality in the frontend:**
  - Added the `deleteRecipe` method in `recipeService` to make DELETE requests to the backend API with proper authorization headers.
  - Implemented the `handleDeleteRecipe` function in `RecipeDetail` to confirm deletion, call the service method, and navigate back to the recipes list upon success.
  - Updated the delete button in `RecipeDetail` to trigger the `handleDeleteRecipe` function.

### Testing Changes

* **Added unit tests for delete recipe functionality:**
  - Mocked `deleteRecipe` in `recipeService` and `useNavigate` from `react-router` for testing purposes. [[1]](diffhunk://#diff-f642f28bc02d672ab5c1ef65b48da0c81aeabf4c49674cace52fc2bfc618b711R20-R22) [[2]](diffhunk://#diff-f642f28bc02d672ab5c1ef65b48da0c81aeabf4c49674cace52fc2bfc618b711R84-R103)
  - Added tests in `RecipeDetail.test.tsx` to verify the presence of the delete button, confirmation dialog behavior, and invocation of the delete function with the correct recipe ID.